### PR TITLE
fix(darwin): fix address assignment on MacOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use error::Error;
 pub use ipnet;
 use ipnet::IpNet;
 use std::collections::HashSet;
+use std::net::IpAddr;
 
 pub mod sys;
 
@@ -18,7 +19,10 @@ pub struct Interface(sys::InterfaceHandle);
 impl Interface {
     delegate! {
         to self.0 {
+            #[cfg(not(target_os = "macos"))]
             pub fn add_address(&self, network: IpNet) -> Result<(), Error>;
+            #[cfg(target_os = "macos")]
+            pub fn add_address(&self, address: IpAddr, dest_network: IpNet) -> Result<(), Error>;
             pub fn remove_address(&self, network: IpNet) -> Result<(), Error>;
             /// Returns array of IP addresses, assigned to this Interface
             pub fn addresses(&self) -> Result<Vec<IpNet>, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ pub use error::Error;
 pub use ipnet;
 use ipnet::IpNet;
 use std::collections::HashSet;
-use std::net::IpAddr;
 
 pub mod sys;
 
@@ -19,10 +18,7 @@ pub struct Interface(sys::InterfaceHandle);
 impl Interface {
     delegate! {
         to self.0 {
-            #[cfg(not(target_os = "macos"))]
             pub fn add_address(&self, network: IpNet) -> Result<(), Error>;
-            #[cfg(target_os = "macos")]
-            pub fn add_address(&self, address: IpAddr, dest_network: IpNet) -> Result<(), Error>;
             pub fn remove_address(&self, network: IpNet) -> Result<(), Error>;
             /// Returns array of IP addresses, assigned to this Interface
             pub fn addresses(&self) -> Result<Vec<IpNet>, Error>;

--- a/src/sys/darwin/handle.rs
+++ b/src/sys/darwin/handle.rs
@@ -16,20 +16,20 @@ pub trait InterfaceExt {
 }
 
 impl InterfaceHandle {
-    pub fn add_address(&self, network: IpNet) -> Result<(), Error> {
+    pub fn add_address(&self, address: net::IpAddr, dest_network: IpNet) -> Result<(), Error> {
         let socket = dummy_socket()?;
         let name = self.name()?;
-        match network {
-            IpNet::V4(addr4) => {
-                let ifra_addr = SockaddrIn::from(net::SocketAddrV4::new(addr4.addr(), 0));
-                let ifra_broadaddr = SockaddrIn::from(net::SocketAddrV4::new(addr4.broadcast(), 0));
-                let ifra_mask = SockaddrIn::from(net::SocketAddrV4::new(addr4.netmask(), 0));
+        match (address, dest_network) {
+            (net::IpAddr::V4(address), IpNet::V4(network)) => {
+                let ifra_addr = SockaddrIn::from(net::SocketAddrV4::new(address, 0));
+                let ifra_dest_addr = SockaddrIn::from(net::SocketAddrV4::new(network.addr(), 0));
+                let ifra_dest_mask = SockaddrIn::from(net::SocketAddrV4::new(network.netmask(), 0));
 
                 let req = ifreq::ifaliasreq4 {
                     ifra_name: name.parse().unwrap(),
                     ifra_addr: *ifra_addr.as_ref(),
-                    ifra_broadaddr: *ifra_broadaddr.as_ref(),
-                    ifra_mask: *ifra_mask.as_ref(),
+                    ifra_broadaddr: *ifra_dest_addr.as_ref(),
+                    ifra_mask: *ifra_dest_mask.as_ref(),
                 };
 
                 unsafe {
@@ -37,17 +37,18 @@ impl InterfaceHandle {
                 }
                 Ok(())
             }
-            IpNet::V6(addr6) => {
-                let ifra_addr = SockaddrIn6::from(net::SocketAddrV6::new(addr6.addr(), 0, 0, 0));
-                let ifra_broadaddr =
-                    SockaddrIn6::from(net::SocketAddrV6::new(addr6.broadcast(), 0, 0, 0));
-                let ifra_mask = SockaddrIn6::from(net::SocketAddrV6::new(addr6.netmask(), 0, 0, 0));
+            (net::IpAddr::V6(address), IpNet::V6(network)) => {
+                let ifra_addr = SockaddrIn6::from(net::SocketAddrV6::new(address, 0, 0, 0));
+                let ifra_dest_addr =
+                    SockaddrIn6::from(net::SocketAddrV6::new(network.addr(), 0, 0, 0));
+                let ifra_dest_mask =
+                    SockaddrIn6::from(net::SocketAddrV6::new(network.netmask(), 0, 0, 0));
 
                 let req = ifreq::ifaliasreq6 {
                     ifra_name: name.parse().unwrap(),
                     ifra_addr: *ifra_addr.as_ref(),
-                    ifra_broadaddr: *ifra_broadaddr.as_ref(),
-                    ifra_mask: *ifra_mask.as_ref(),
+                    ifra_broadaddr: *ifra_dest_addr.as_ref(),
+                    ifra_mask: *ifra_dest_mask.as_ref(),
                 };
 
                 unsafe {
@@ -55,6 +56,7 @@ impl InterfaceHandle {
                 }
                 Ok(())
             }
+            _ => Err(Error::InvalidParameter),
         }
     }
 

--- a/src/sys/darwin/handle.rs
+++ b/src/sys/darwin/handle.rs
@@ -16,13 +16,13 @@ pub trait InterfaceExt {
 }
 
 impl InterfaceHandle {
-    pub fn add_address(&self, address: net::IpAddr, dest_network: IpNet) -> Result<(), Error> {
+    pub fn add_address(&self, network: IpNet) -> Result<(), Error> {
         let socket = dummy_socket()?;
         let name = self.name()?;
-        match (address, dest_network) {
-            (net::IpAddr::V4(address), IpNet::V4(network)) => {
-                let ifra_addr = SockaddrIn::from(net::SocketAddrV4::new(address, 0));
-                let ifra_dest_addr = SockaddrIn::from(net::SocketAddrV4::new(network.addr(), 0));
+        match network {
+            IpNet::V4(network) => {
+                let ifra_addr = SockaddrIn::from(net::SocketAddrV4::new(network.addr(), 0));
+                let ifra_dest_addr = SockaddrIn::from(net::SocketAddrV4::new(network.network(), 0));
                 let ifra_dest_mask = SockaddrIn::from(net::SocketAddrV4::new(network.netmask(), 0));
 
                 let req = ifreq::ifaliasreq4 {
@@ -37,10 +37,10 @@ impl InterfaceHandle {
                 }
                 Ok(())
             }
-            (net::IpAddr::V6(address), IpNet::V6(network)) => {
-                let ifra_addr = SockaddrIn6::from(net::SocketAddrV6::new(address, 0, 0, 0));
+            IpNet::V6(network) => {
+                let ifra_addr = SockaddrIn6::from(net::SocketAddrV6::new(network.addr(), 0, 0, 0));
                 let ifra_dest_addr =
-                    SockaddrIn6::from(net::SocketAddrV6::new(network.addr(), 0, 0, 0));
+                    SockaddrIn6::from(net::SocketAddrV6::new(network.network(), 0, 0, 0));
                 let ifra_dest_mask =
                     SockaddrIn6::from(net::SocketAddrV6::new(network.netmask(), 0, 0, 0));
 
@@ -56,7 +56,6 @@ impl InterfaceHandle {
                 }
                 Ok(())
             }
-            _ => Err(Error::InvalidParameter),
         }
     }
 

--- a/src/sys/posix/handle.rs
+++ b/src/sys/posix/handle.rs
@@ -38,7 +38,7 @@ impl InterfaceHandle {
     }
 
     pub fn mtu(&self) -> Result<u32, Error> {
-        let mut req = ifreq::new(&self.name()?);
+        let mut req = ifreq::new(self.name()?);
         let socket = dummy_socket()?;
 
         unsafe {

--- a/src/sys/posix/mod.rs
+++ b/src/sys/posix/mod.rs
@@ -10,7 +10,7 @@ use std::net;
 pub(crate) mod ioctls;
 
 pub(crate) fn dummy_socket() -> Result<net::UdpSocket, Error> {
-    Ok(net::UdpSocket::bind("[::1]:0")?)
+    Ok(net::UdpSocket::bind("0:0")?)
 }
 
 pub(crate) fn list_interfaces() -> Result<Vec<crate::Interface>, Error> {


### PR DESCRIPTION
This PR fixes multiple issues with address assignment on MacOS:
- bad dummy socket IP which caused all address operations to throw `EINVAL`.
- address assignment for TUN interfaces on MacOS works differently than on Linux, as you do not only specify the address of the interface, but also the destination address/network

Any changes, ideas and code style improvements welcome!

Fixes #69.